### PR TITLE
Add ftdetect for CMake filetypes.

### DIFF
--- a/ftdetect/cmake.vim
+++ b/ftdetect/cmake.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead CMakeLists,CMakeLists.txt setlocal filetype=cmake
+au BufNewFile,BufRead *.cmake,CMakeLists.txt setlocal filetype=cmake

--- a/ftdetect/cmake.vim
+++ b/ftdetect/cmake.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead CMakeLists,CMakeLists.txt setlocal filetype=cmake

--- a/ftdetect/cmake.vim
+++ b/ftdetect/cmake.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.cmake,CMakeLists.txt setlocal filetype=cmake
+au BufNewFile,BufRead *.cmake setlocal filetype=cmake


### PR DESCRIPTION
Add `ftdetect` directory for detecting CMake filetypes.